### PR TITLE
feat: propagate Kubernetes metadata to Google CAS labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,44 @@ NAME                                     TYPE                                  D
 secret/demo-cert-tls                     kubernetes.io/tls                     3      1m
 ```
 
+### Metadata Propagation (Label Sync)
+
+The Google CAS Issuer automatically synchronizes Kubernetes metadata to the issued certificates in Google Cloud CAS using **Labels**.
+
+#### Automatic Synchronization of Labels
+
+Any labels defined in the `metadata.labels` section of a `Certificate` (or `CertificateRequest`) are automatically propagated to the Google CAS certificate.
+
+*   **Sanitization**: Kubernetes labels are automatically sanitized to meet GCP's strict requirements (lowercase, alphanumeric, dashes, or underscores; max 63 characters).
+*   **Key Mapping**: If a label key starts with a non-alphabetic character (like a number), it is automatically prefixed with `l-` to comply with GCP API constraints.
+
+#### Operational Provenance Labels
+
+In addition to custom labels, the issuer automatically injects the following provenance metadata into every issued certificate:
+
+*   `cert-manager-io_certificate-name`: The name of the parent `Certificate` resource.
+*   `cert-manager-io_certificate-request-name`: The name of the `CertificateRequest` resource.
+*   `cert-manager-io_certificate-request-namespace`: The namespace where the request originated.
+
+#### Example
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-app-cert
+  namespace: production
+  labels:
+    # These will appear in the Google Cloud CAS Console
+    team: "platform-identity"
+    cost-center: "442"
+spec:
+  secretName: my-app-cert-tls
+  issuerRef:
+    name: googlecasclusterissuer-sample
+    kind: GoogleCASClusterIssuer
+```
+
 ## Continuous Integration
 
 This project uses GitHub Actions to run continuous integration tests.

--- a/pkg/controllers/signer.go
+++ b/pkg/controllers/signer.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"sort"
 	"strings"
 	"time"
 
@@ -136,6 +137,7 @@ func (o *GoogleCAS) Sign(ctx context.Context, cr signer.CertificateRequestObject
 				Nanos:   0,
 			},
 			CertificateTemplate: issuerSpec.CertificateTemplate,
+			Labels:              o.buildCertificateLabels(cr),
 		},
 		RequestId:                     uuid.New().String(),
 		IssuingCertificateAuthorityId: issuerSpec.CertificateAuthorityId,
@@ -297,4 +299,80 @@ func filterAndDeduplicateCAs(caChains []*casapi.FetchCaCertsResponse_CertChain) 
 		}
 	}
 	return caBuf.Bytes(), nil
+}
+
+const maxCertificateLabels = 60
+
+// buildCertificateLabels constructs a map of labels to be applied to a Google CAS Certificate.
+// It extracts native Kubernetes labels from the CertificateRequest (which natively inherits
+// them from the parent Certificate), and applies GCP-compliant sanitization before returning
+// the final map. To ensure idempotency and auditability, it injects provenance metadata first
+// and then processes the remaining labels in a deterministic, alphabetically sorted order until
+// the maxCertificateLabels limit is reached.
+func (o *GoogleCAS) buildCertificateLabels(cr signer.CertificateRequestObject) map[string]string {
+	labels := make(map[string]string)
+	annotations := cr.GetAnnotations()
+	nativeLabels := cr.GetLabels()
+
+	addLabel := func(key, value string) {
+		if key == "" || len(labels) >= maxCertificateLabels {
+			return
+		}
+		if _, exists := labels[key]; exists {
+			return
+		}
+		labels[key] = value
+	}
+
+	// Auto-inject provenance first so it is not dropped at the cap.
+	if parentCertName := annotations["cert-manager.io/certificate-name"]; parentCertName != "" {
+		addLabel(sanitizeGCPLabel("cert-manager-io_certificate-name", true), sanitizeGCPLabel(parentCertName, false))
+	}
+	addLabel(sanitizeGCPLabel("cert-manager-io_certificate-request-name", true), sanitizeGCPLabel(cr.GetName(), false))
+	addLabel(sanitizeGCPLabel("cert-manager-io_certificate-request-namespace", true), sanitizeGCPLabel(cr.GetNamespace(), false))
+
+	keys := make([]string, 0, len(nativeLabels))
+	for k := range nativeLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		addLabel(sanitizeGCPLabel(k, true), sanitizeGCPLabel(nativeLabels[k], false))
+	}
+
+	return labels
+}
+
+// sanitizeGCPLabel ensures that a string conforms to the strict requirements for GCP labels.
+// GCP Constraints for both Keys and Values:
+// 1. Length must be between 1 and 63 characters (after sanitization).
+// 2. Can only contain lowercase letters, numeric characters, underscores (_), and dashes (-).
+//
+// Additional Constraint for Keys (when isKey is true):
+// 3. Must start with a lowercase letter.
+//
+// This function forces lowercase, replaces invalid characters with underscores, and
+// for keys, prefixes with 'l-' if the first character is non-alphabetic.
+func sanitizeGCPLabel(s string, isKey bool) string {
+	if s == "" {
+		return ""
+	}
+	s = strings.ToLower(s)
+	if isKey && (len(s) == 0 || s[0] < 'a' || s[0] > 'z') {
+		s = "l-" + s
+	}
+	var sb strings.Builder
+	for _, ch := range s {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
+			sb.WriteRune(ch)
+		} else {
+			sb.WriteRune('_')
+		}
+	}
+	res := sb.String()
+	if len(res) > 63 {
+		return res[:63]
+	}
+	return res
 }

--- a/pkg/controllers/signer_test.go
+++ b/pkg/controllers/signer_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cert-manager/issuer-lib/controllers/signer"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/genproto/googleapis/cloud/security/privateca/v1"
 
@@ -294,4 +295,93 @@ func generateTestCert(t *testing.T, isCA bool, subject, issuer string, expiry ti
 	}
 
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// Mock structure for CertificateRequestObject interface
+type mockCR struct {
+	signer.CertificateRequestObject
+	name        string
+	namespace   string
+	annotations map[string]string
+	labels      map[string]string
+}
+
+func (m *mockCR) GetName() string                   { return m.name }
+func (m *mockCR) GetNamespace() string              { return m.namespace }
+func (m *mockCR) GetAnnotations() map[string]string { return m.annotations }
+func (m *mockCR) GetLabels() map[string]string      { return m.labels }
+
+func TestSanitizeGCPLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		isKey    bool
+		expected string
+	}{
+		{"Valid Label", "team-engineering", true, "team-engineering"},
+		{"Uppercase to Lowercase", "Team-Engineering", true, "team-engineering"},
+		{"Invalid Characters Replaced", "tenant/123@region", false, "tenant_123_region"},
+		{"Key Starts with Number", "123-tenant", true, "l-123-tenant"},
+		{"Key Starts with Alphabet", "a123-tenant", true, "a123-tenant"},
+		{"Value Starts with Number", "123-tenant", false, "123-tenant"},
+		{"Exceeds 63 characters", "this-is-a-very-long-label-that-is-way-longer-than-sixty-three-characters", true, "this-is-a-very-long-label-that-is-way-longer-than-sixty-three-c"},
+		{"Empty string", "", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeGCPLabel(tt.input, tt.isKey)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBuildCertificateLabels(t *testing.T) {
+	googleCAS := &GoogleCAS{}
+
+	// Test case: Base generation with origin tags and K8s labels
+	cr1 := &mockCR{
+		name:      "test-request",
+		namespace: "default",
+		annotations: map[string]string{
+			"cert-manager.io/certificate-name": "parent-cert",
+			"some-other-annotation":            "ignored",
+		},
+		labels: map[string]string{
+			"team":         "platform",
+			"Cost-Center!": "999",     // uppercase and exclamation
+			"1st-region":   "us-east", // key starts with number
+		},
+	}
+
+	labels1 := googleCAS.buildCertificateLabels(cr1)
+
+	// Expect native k8s origin labels to be synced automatically
+	assert.Equal(t, "parent-cert", labels1["cert-manager-io_certificate-name"])
+	assert.Equal(t, "test-request", labels1["cert-manager-io_certificate-request-name"])
+	assert.Equal(t, "default", labels1["cert-manager-io_certificate-request-namespace"])
+
+	// Expect proper sanitization of K8s native metadata.labels
+	assert.Equal(t, "platform", labels1["team"])
+	assert.Equal(t, "999", labels1["cost-center_"])
+	assert.Equal(t, "us-east", labels1["l-1st-region"]) // Key must be prepended with l-
+
+	// Test case: Max Label Truncation natively
+	bigLabels := make(map[string]string)
+	for i := range 70 {
+		bigLabels[fmt.Sprintf("key-%d", i)] = "val"
+	}
+
+	cr2 := &mockCR{
+		name:      "massive-label-request",
+		namespace: "default",
+		labels:    bigLabels,
+	}
+
+	labels2 := googleCAS.buildCertificateLabels(cr2)
+	assert.LessOrEqual(t, len(labels2), 60) // Should truncate above 60 keys natively downstream
+
+	// Explicitly assert that the provenance metadata unconditionally survived the 60-label truncation!
+	assert.Equal(t, "massive-label-request", labels2["cert-manager-io_certificate-request-name"])
+	assert.Equal(t, "default", labels2["cert-manager-io_certificate-request-namespace"])
 }


### PR DESCRIPTION
Add metadata label propagation that when configured causes `Labels` in the generated Google CAS certificate to contain native Kubernetes certificate labels and provenance metadata.

This PR adds label propagation logic to the [Sign](https://github.com/cert-manager/google-cas-issuer/blob/main/pkg/controllers/signer.go#L107) method. It intercepts standard K8s labels automatically copied from the `Certificate` to the `CertificateRequest` and passes them downstream to the CAS API `Labels` map. To ensure robust reliability against GCP's strict API constraints, it introduces a `sanitizeGCPLabel` helper to filter the K8s labels by the following criteria:
* The label is strictly forced to lowercase, and non-alphanumeric characters are replaced with underscores (`_`).
* The key length is strictly capped at 63 characters to prevent webhook rejection.
* Each label key is guaranteed to start with a lowercase letter (prefixed with `l-` if it begins with a digit).

To ensure baseline auditability regardless of developer input, the issuer also automatically injects three K8s fields as CAS labels on all certificates:
*   `cert-manager-io_certificate-name` (Derived from the parent certificate)
*   `cert-manager-io_certificate-request-name`
*   `cert-manager-io_certificate-request-namespace`

The standard Kubernetes `Certificate` definition would look like the following:
```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: payment-gateway-tls
  namespace: finance-dept
  labels:
     cluster_id: "fin-edge-dev-cluster"
     env: "dev"
     project_id: "fin-edge-dev"
```

The resulting certificate in the Google Cloud Console will automatically possess:
* `cluster_id: fin-edge-dev-cluster`
* `env: dev`
* `project_id: fin-edge-dev`
* `cert-manager-io_certificate-name: payment-gateway-tls`
* `cert-manager-io_certificate-request-name: payment-gateway-tls-1`
* `cert-manager-io_certificate-request-namespace: finance-dept`

The suggested change is non-breaking, relies entirely on the offline `CertificateRequest` struct natively without expanding the Operator's RBAC footprint, and does not affect existing workloads.

Fixes #485
