### PR TITLE
feat: add secondary CA pool failover support for high availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ gcloud privateca pools add-iam-policy-binding my-pool --role=roles/privateca.poo
 ```
 
 
+
 ### Multi-tenancy and security considerations
 
 > [!IMPORTANT]
@@ -159,6 +160,7 @@ To keep tenants isolated:
 - **Scope the controller's IAM to only the pools you intend to expose.** Bind `roles/privateca.certificateRequester` per pool (as shown above), not at project or folder scope. Broader grants widen the blast radius to every pool in that scope.
 - **Restrict who can create issuer and certificate objects.** Use Kubernetes RBAC to limit `create` on `googlecasissuers.cas-issuer.jetstack.io` and `certificaterequests.cert-manager.io` in tenant namespaces.
 - **Prefer explicit per-tenant credentials when tenants must target distinct pools.** Give each tenant a `spec.credentials` Secret referencing a service account scoped to only their pool, rather than relying on the shared ambient identity.
+
 
 #### Inside GKE with workload identity
 
@@ -271,11 +273,11 @@ spec:
 kubectl apply -f googlecasclusterissuer-sample.yaml
 ```
 
-### Failover / Secondary CA Pool (High Availability)
+### Failover / Fallback CA Pools (High Availability)
 
-You can configure a secondary CA pool for automatic failover. If the primary CA pool fails to issue a certificate (e.g., due to a regional outage or quota exhaustion), the controller will automatically retry using the secondary pool.
+You can configure one or more fallback CA pools for automatic failover. If the primary CA pool fails to issue a certificate (e.g., due to a regional outage or quota exhaustion), the controller will automatically try each fallback pool in order until one succeeds.
 
-All secondary fields are **optional** — if omitted, the issuer behaves exactly as before.
+All fallback configuration is **optional** — if omitted, the issuer behaves exactly as before.
 
 ```yaml
 apiVersion: cas-issuer.jetstack.io/v1beta1
@@ -290,34 +292,32 @@ spec:
   credentials:
     name: "googlesa"
     key: "$PROJECT_ID-key.json"
-  # Failover configuration (all optional)
-  secondaryCaPoolId: dr-pool
-  secondaryLocation: us-west1
-  secondaryCertificateTemplate: projects/$PROJECT_ID/locations/us-west1/certificateTemplates/dr-template
-  # secondaryCertificateAuthorityId: ""  # omit to load balance across all CAs in the secondary pool
+  # Fallback configuration (optional, supports multiple entries)
+  fallbacks:
+    - project: $PROJECT_ID # same project, different region
+      caPoolId: dr-pool
+      location: us-west1
+      # certificateAuthorityId: ""  # omit to load balance across all CAs
+    - project: backup-project # different GCP project
+      caPoolId: eu-backup-pool
+      location: europe-west1
+      certificateTemplate: projects/backup-project/locations/europe-west1/certificateTemplates/eu-template
 ```
 
-**Required secondary fields for failover to activate:**
+**Each fallback entry requires:**
 | Field | Description |
 |-------|-------------|
-| `secondaryCaPoolId` | CA pool ID for the fallback pool |
-| `secondaryLocation` | GCP location of the fallback pool (independent from primary) |
-| `secondaryCertificateTemplate` | Certificate template for the fallback pool |
+| `project` | GCP project ID for this fallback pool |
+| `caPoolId` | CA pool ID for the fallback pool |
+| `location` | GCP location of the fallback pool |
 
-**Optional:**
+**Optional per fallback:**
 | Field | Description |
 |-------|-------------|
-| `secondaryCertificateAuthorityId` | Specific CA within the fallback pool. Omit to load balance across all CAs. |
+| `certificateTemplate` | Certificate template for the fallback pool |
+| `certificateAuthorityId` | Specific CA within the fallback pool. Omit to load balance across all CAs. |
 
-> **IAM:** The service account must have `roles/privateca.certificateRequester` on **both** the primary and secondary CA pools.
->
-> ```shell
-> # Grant access to the secondary pool
-> gcloud privateca pools add-iam-policy-binding dr-pool \
->   --role=roles/privateca.certificateRequester \
->   --member="serviceAccount:sa-google-cas-issuer@$PROJECT_ID.iam.gserviceaccount.com" \
->   --location=us-west1
-> ```
+> **IAM:** The service account must have `roles/privateca.certificateRequester` on **all** configured CA pools (primary and all fallbacks).
 
 ### Creating your first certificate
 
@@ -368,6 +368,7 @@ secret/demo-cert-tls                     kubernetes.io/tls                     3
 
 This project uses GitHub Actions to run continuous integration tests.
 There are two required test workflows:
+
 - `run_unit_tests` - this runs automatically on every pull request
 - `run_e2e_tests` - this runs on a pull request when the `ok-to-test` label is added  
-**⚠️ IMPORTANT: A maintainer must add this label manually after verifying that the commits in your PR are non-malicious. Ping a maintainer when your PR is ready. This label has to be re-added every time a change is made in the PR.**
+  **⚠️ IMPORTANT: A maintainer must add this label manually after verifying that the commits in your PR are non-malicious. Ping a maintainer when your PR is ready. This label has to be re-added every time a change is made in the PR.**

--- a/README.md
+++ b/README.md
@@ -271,6 +271,54 @@ spec:
 kubectl apply -f googlecasclusterissuer-sample.yaml
 ```
 
+### Failover / Secondary CA Pool (High Availability)
+
+You can configure a secondary CA pool for automatic failover. If the primary CA pool fails to issue a certificate (e.g., due to a regional outage or quota exhaustion), the controller will automatically retry using the secondary pool.
+
+All secondary fields are **optional** — if omitted, the issuer behaves exactly as before.
+
+```yaml
+apiVersion: cas-issuer.jetstack.io/v1beta1
+kind: GoogleCASIssuer
+metadata:
+  name: ha-issuer
+spec:
+  project: $PROJECT_ID
+  location: us-east1
+  caPoolId: primary-pool
+  certificateTemplate: projects/$PROJECT_ID/locations/us-east1/certificateTemplates/my-template
+  credentials:
+    name: "googlesa"
+    key: "$PROJECT_ID-key.json"
+  # Failover configuration (all optional)
+  secondaryCaPoolId: dr-pool
+  secondaryLocation: us-west1
+  secondaryCertificateTemplate: projects/$PROJECT_ID/locations/us-west1/certificateTemplates/dr-template
+  # secondaryCertificateAuthorityId: ""  # omit to load balance across all CAs in the secondary pool
+```
+
+**Required secondary fields for failover to activate:**
+| Field | Description |
+|-------|-------------|
+| `secondaryCaPoolId` | CA pool ID for the fallback pool |
+| `secondaryLocation` | GCP location of the fallback pool (independent from primary) |
+| `secondaryCertificateTemplate` | Certificate template for the fallback pool |
+
+**Optional:**
+| Field | Description |
+|-------|-------------|
+| `secondaryCertificateAuthorityId` | Specific CA within the fallback pool. Omit to load balance across all CAs. |
+
+> **IAM:** The service account must have `roles/privateca.certificateRequester` on **both** the primary and secondary CA pools.
+>
+> ```shell
+> # Grant access to the secondary pool
+> gcloud privateca pools add-iam-policy-binding dr-pool \
+>   --role=roles/privateca.certificateRequester \
+>   --member="serviceAccount:sa-google-cas-issuer@$PROJECT_ID.iam.gserviceaccount.com" \
+>   --location=us-west1
+> ```
+
 ### Creating your first certificate
 
 You can now create certificates as normal, but ensure the `IssuerRef` is set to the `GoogleCASIssuer` or `GoogleCASClusterIssuer` created in the previous step.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ gcloud privateca pools add-iam-policy-binding my-pool --role=roles/privateca.poo
 ```
 
 
-
 ### Multi-tenancy and security considerations
 
 > [!IMPORTANT]
@@ -160,7 +159,6 @@ To keep tenants isolated:
 - **Scope the controller's IAM to only the pools you intend to expose.** Bind `roles/privateca.certificateRequester` per pool (as shown above), not at project or folder scope. Broader grants widen the blast radius to every pool in that scope.
 - **Restrict who can create issuer and certificate objects.** Use Kubernetes RBAC to limit `create` on `googlecasissuers.cas-issuer.jetstack.io` and `certificaterequests.cert-manager.io` in tenant namespaces.
 - **Prefer explicit per-tenant credentials when tenants must target distinct pools.** Give each tenant a `spec.credentials` Secret referencing a service account scoped to only their pool, rather than relying on the shared ambient identity.
-
 
 #### Inside GKE with workload identity
 
@@ -368,7 +366,6 @@ secret/demo-cert-tls                     kubernetes.io/tls                     3
 
 This project uses GitHub Actions to run continuous integration tests.
 There are two required test workflows:
-
 - `run_unit_tests` - this runs automatically on every pull request
 - `run_e2e_tests` - this runs on a pull request when the `ok-to-test` label is added  
-  **⚠️ IMPORTANT: A maintainer must add this label manually after verifying that the commits in your PR are non-malicious. Ping a maintainer when your PR is ready. This label has to be re-added every time a change is made in the PR.**
+**⚠️ IMPORTANT: A maintainer must add this label manually after verifying that the commits in your PR are non-malicious. Ping a maintainer when your PR is ready. This label has to be re-added every time a change is made in the PR.**

--- a/api/v1beta1/googlecasissuer_types.go
+++ b/api/v1beta1/googlecasissuer_types.go
@@ -48,6 +48,24 @@ type GoogleCASIssuerSpec struct {
 	// +optional
 	CertificateTemplate string `json:"certificateTemplate,omitempty"`
 
+	// SecondaryCaPoolId is the id of a fallback CA pool to issue certificates from if the primary pool fails
+	// +optional
+	SecondaryCaPoolId string `json:"secondaryCaPoolId,omitempty"`
+
+	// SecondaryLocation is the Google Cloud Project Location for the secondary CA pool.
+	// +optional
+	SecondaryLocation string `json:"secondaryLocation,omitempty"`
+
+	// SecondaryCertificateTemplate is specific certificate template to
+	// +optional
+	SecondaryCertificateTemplate string `json:"secondaryCertificateTemplate,omitempty"`
+
+	// SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
+	// use to sign. Omit in order to load balance across all CAs
+	// in the pool
+	// +optional
+	SecondaryCertificateAuthorityId string `json:"secondaryCertificateAuthorityId,omitempty"`
+
 	// CAFetchMode controls how the CA certificate chain is fetched and constructed.
 	// Possible values: "CA" (default), "PoolCAs".
 	// "CA": ca.crt contains root CA certificate of the Certificate Authority Service CA that has issued the certificate.

--- a/api/v1beta1/googlecasissuer_types.go
+++ b/api/v1beta1/googlecasissuer_types.go
@@ -48,23 +48,10 @@ type GoogleCASIssuerSpec struct {
 	// +optional
 	CertificateTemplate string `json:"certificateTemplate,omitempty"`
 
-	// SecondaryCaPoolId is the id of a fallback CA pool to issue certificates from if the primary pool fails
+	// Fallbacks is an ordered list of fallback CA pools to try if the primary pool fails.
+	// The controller will attempt each fallback in order until one succeeds.
 	// +optional
-	SecondaryCaPoolId string `json:"secondaryCaPoolId,omitempty"`
-
-	// SecondaryLocation is the Google Cloud Project Location for the secondary CA pool.
-	// +optional
-	SecondaryLocation string `json:"secondaryLocation,omitempty"`
-
-	// SecondaryCertificateTemplate is specific certificate template to
-	// +optional
-	SecondaryCertificateTemplate string `json:"secondaryCertificateTemplate,omitempty"`
-
-	// SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
-	// use to sign. Omit in order to load balance across all CAs
-	// in the pool
-	// +optional
-	SecondaryCertificateAuthorityId string `json:"secondaryCertificateAuthorityId,omitempty"`
+	Fallbacks []FallbackCAPool `json:"fallbacks,omitempty"`
 
 	// CAFetchMode controls how the CA certificate chain is fetched and constructed.
 	// Possible values: "CA" (default), "PoolCAs".
@@ -72,6 +59,28 @@ type GoogleCASIssuerSpec struct {
 	// "PoolCAs": ca.crt contains all root CA certificates of all ENABLED, DISABLED, or STAGED Certificate Authority Service CA Pool CAs that are not expired.
 	// +optional
 	CAFetchMode CAFetchMode `json:"caFetchMode,omitempty"`
+}
+
+// FallbackCAPool defines a fallback CA pool configuration for failover.
+// If the primary CA pool fails, the controller will attempt each fallback in order.
+type FallbackCAPool struct {
+	// Project is the Google Cloud Project ID for this fallback pool.
+	Project string `json:"project"`
+
+	// CaPoolId is the CA pool ID for the fallback pool.
+	CaPoolId string `json:"caPoolId"`
+
+	// Location is the Google Cloud location of the fallback pool.
+	Location string `json:"location"`
+
+	// CertificateTemplate is the certificate template to use with this fallback pool.
+	// +optional
+	CertificateTemplate string `json:"certificateTemplate,omitempty"`
+	
+	// CertificateAuthorityId is a specific certificate authority within the fallback pool.
+	// Omit to load balance across all CAs in the pool.
+	// +optional
+	CertificateAuthorityId string `json:"certificateAuthorityId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=CA;PoolCAs

--- a/api/v1beta1/googlecasissuer_types.go
+++ b/api/v1beta1/googlecasissuer_types.go
@@ -95,6 +95,36 @@ const (
 	CAFetchModePoolCAs CAFetchMode = "PoolCAs"
 )
 
+type CAPoolReference interface {
+	GetProject() string
+	GetLocation() string
+	GetCaPoolId() string
+}
+
+func (s *GoogleCASIssuerSpec) GetProject() string {
+		return s.Project
+}
+
+func (s *GoogleCASIssuerSpec) GetLocation() string {
+		return s.Location
+}
+
+func (s *GoogleCASIssuerSpec) GetCaPoolId() string {
+		return s.CaPoolId
+}
+
+func (f FallbackCAPool) GetProject() string  { 
+		return f.Project
+}
+
+func (f FallbackCAPool) GetLocation() string { 
+		return f.Location
+}
+
+func (f FallbackCAPool) GetCaPoolId() string { 
+		return f.CaPoolId
+}
+
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"

--- a/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasclusterissuers.yaml
+++ b/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasclusterissuers.yaml
@@ -100,21 +100,34 @@ spec:
                 project:
                   description: Project is the Google Cloud Project ID
                   type: string
-                secondaryCaPoolId:
-                  description: SecondaryCaPoolId is the id of a fallback CA pool to issue certificates from if the primary pool fails
-                  type: string
-                secondaryCertificateAuthorityId:
+                fallbacks:
                   description: |-
-                    SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
-                    use to sign. Omit in order to load balance across all CAs
-                    in the pool
-                  type: string
-                secondaryCertificateTemplate:
-                  description: SecondaryCertificateTemplate is specific certificate template to use with the secondary CA pool
-                  type: string
-                secondaryLocation:
-                  description: SecondaryLocation is the Google Cloud Project Location for the secondary CA pool.
-                  type: string
+                    Fallbacks is an ordered list of fallback CA pools. If the primary pool fails,
+                    the controller tries each fallback in order until one succeeds.
+                  items:
+                    description: FallbackCAPool defines a fallback CA pool configuration for failover.
+                    properties:
+                      caPoolId:
+                        description: CaPoolId is the CA pool ID for the fallback pool.
+                        type: string
+                      certificateAuthorityId:
+                        description: |-
+                          CertificateAuthorityId is a specific certificate authority within the fallback pool.
+                          Omit to load balance across all CAs in the pool.
+                        type: string
+                      certificateTemplate:
+                        description: CertificateTemplate is the certificate template to use with this fallback pool. Omit to not specify a template
+                        type: string
+                      location:
+                        description: Location is the Google Cloud location of the fallback pool.
+                        type: string
+                      project:
+                        description: Project is the Google Cloud Project ID for this fallback pool.
+                        type: string
+                    required:
+                      - project
+                      - caPoolId
+                      - location
               type: object
             status:
               properties:

--- a/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasclusterissuers.yaml
+++ b/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasclusterissuers.yaml
@@ -100,6 +100,21 @@ spec:
                 project:
                   description: Project is the Google Cloud Project ID
                   type: string
+                secondaryCaPoolId:
+                  description: SecondaryCaPoolId is the id of a fallback CA pool to issue certificates from if the primary pool fails
+                  type: string
+                secondaryCertificateAuthorityId:
+                  description: |-
+                    SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
+                    use to sign. Omit in order to load balance across all CAs
+                    in the pool
+                  type: string
+                secondaryCertificateTemplate:
+                  description: SecondaryCertificateTemplate is specific certificate template to use with the secondary CA pool
+                  type: string
+                secondaryLocation:
+                  description: SecondaryLocation is the Google Cloud Project Location for the secondary CA pool.
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasissuers.yaml
+++ b/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasissuers.yaml
@@ -100,21 +100,36 @@ spec:
                 project:
                   description: Project is the Google Cloud Project ID
                   type: string
-                secondaryCaPoolId:
-                  description: SecondaryCaPoolId is the id of a fallback CA pool to issue certificates from if the primary pool fails
-                  type: string
-                secondaryCertificateAuthorityId:
+                fallbacks:
                   description: |-
-                    SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
-                    use to sign. Omit in order to load balance across all CAs
-                    in the pool
-                  type: string
-                secondaryCertificateTemplate:
-                  description: SecondaryCertificateTemplate is specific certificate template to use with the secondary CA pool
-                  type: string
-                secondaryLocation:
-                  description: SecondaryLocation is the Google Cloud Project Location for the secondary CA pool.
-                  type: string
+                    Fallbacks is an ordered list of fallback CA pools. If the primary pool fails,
+                    the controller tries each fallback in order until one succeeds.
+                  items:
+                    description: FallbackCAPool defines a fallback CA pool configuration for failover.
+                    properties:
+                      caPoolId:
+                        description: CaPoolId is the CA pool ID for the fallback pool.
+                        type: string
+                      certificateAuthorityId:
+                        description: |-
+                          CertificateAuthorityId is a specific certificate authority within the fallback pool.
+                          Omit to load balance across all CAs in the pool.
+                        type: string
+                      certificateTemplate:
+                        description: CertificateTemplate is the certificate template to use with this fallback pool. Omit in order to load balance across all CAs
+                        type: string
+                      location:
+                        description: Location is the Google Cloud location of the fallback pool.
+                        type: string
+                      project:
+                        description: Project is the Google Cloud Project ID for this fallback pool.
+                        type: string
+                    required:
+                      - project
+                      - caPoolId
+                      - location
+                    type: object
+                  type: array
               type: object
             status:
               properties:

--- a/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasissuers.yaml
+++ b/deploy/charts/google-cas-issuer/templates/crd-cas-issuer.jetstack.io_googlecasissuers.yaml
@@ -100,6 +100,21 @@ spec:
                 project:
                   description: Project is the Google Cloud Project ID
                   type: string
+                secondaryCaPoolId:
+                  description: SecondaryCaPoolId is the id of a fallback CA pool to issue certificates from if the primary pool fails
+                  type: string
+                secondaryCertificateAuthorityId:
+                  description: |-
+                    SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
+                    use to sign. Omit in order to load balance across all CAs
+                    in the pool
+                  type: string
+                secondaryCertificateTemplate:
+                  description: SecondaryCertificateTemplate is specific certificate template to use with the secondary CA pool
+                  type: string
+                secondaryLocation:
+                  description: SecondaryLocation is the Google Cloud Project Location for the secondary CA pool.
+                  type: string
               type: object
             status:
               properties:

--- a/deploy/crds/cas-issuer.jetstack.io_googlecasclusterissuers.yaml
+++ b/deploy/crds/cas-issuer.jetstack.io_googlecasclusterissuers.yaml
@@ -99,24 +99,40 @@ spec:
               project:
                 description: Project is the Google Cloud Project ID
                 type: string
-              secondaryCaPoolId:
-                description: SecondaryCaPoolId is the id of a fallback CA pool to issue
-                  certificates from if the primary pool fails
-                type: string
-              secondaryCertificateAuthorityId:
+              fallbacks:
                 description: |-
-                  SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
-                  use to sign. Omit in order to load balance across all CAs
-                  in the pool
-                type: string
-              secondaryCertificateTemplate:
-                description: SecondaryCertificateTemplate is specific certificate template
-                  to use with the secondary CA pool
-                type: string
-              secondaryLocation:
-                description: SecondaryLocation is the Google Cloud Project Location
-                  for the secondary CA pool.
-                type: string
+                  Fallbacks is an ordered list of fallback CA pools. If the primary pool fails,
+                  the controller tries each fallback in order until one succeeds.
+                items:
+                  description: FallbackCAPool defines a fallback CA pool configuration
+                    for failover.
+                  properties:
+                    caPoolId:
+                      description: CaPoolId is the CA pool ID for the fallback pool.
+                      type: string
+                    certificateAuthorityId:
+                      description: |-
+                        CertificateAuthorityId is a specific certificate authority within the fallback pool.
+                        Omit to load balance across all CAs in the pool.
+                      type: string
+                    certificateTemplate:
+                      description: CertificateTemplate is the certificate template
+                        to use with this fallback pool. Omit to not specify a template
+                      type: string
+                    location:
+                      description: Location is the Google Cloud location of the fallback
+                        pool.
+                      type: string
+                    project:
+                      description: Project is the Google Cloud Project ID for this
+                        fallback pool.
+                      type: string
+                  required:
+                  - project
+                  - caPoolId
+                  - location
+                  type: object
+                type: array
             type: object
           status:
             properties:

--- a/deploy/crds/cas-issuer.jetstack.io_googlecasclusterissuers.yaml
+++ b/deploy/crds/cas-issuer.jetstack.io_googlecasclusterissuers.yaml
@@ -99,6 +99,24 @@ spec:
               project:
                 description: Project is the Google Cloud Project ID
                 type: string
+              secondaryCaPoolId:
+                description: SecondaryCaPoolId is the id of a fallback CA pool to issue
+                  certificates from if the primary pool fails
+                type: string
+              secondaryCertificateAuthorityId:
+                description: |-
+                  SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
+                  use to sign. Omit in order to load balance across all CAs
+                  in the pool
+                type: string
+              secondaryCertificateTemplate:
+                description: SecondaryCertificateTemplate is specific certificate template
+                  to use with the secondary CA pool
+                type: string
+              secondaryLocation:
+                description: SecondaryLocation is the Google Cloud Project Location
+                  for the secondary CA pool.
+                type: string
             type: object
           status:
             properties:

--- a/deploy/crds/cas-issuer.jetstack.io_googlecasissuers.yaml
+++ b/deploy/crds/cas-issuer.jetstack.io_googlecasissuers.yaml
@@ -98,6 +98,24 @@ spec:
               project:
                 description: Project is the Google Cloud Project ID
                 type: string
+              secondaryCaPoolId:
+                description: SecondaryCaPoolId is the id of a fallback CA pool to issue
+                  certificates from if the primary pool fails
+                type: string
+              secondaryCertificateAuthorityId:
+                description: |-
+                  SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
+                  use to sign. Omit in order to load balance across all CAs
+                  in the pool
+                type: string
+              secondaryCertificateTemplate:
+                description: SecondaryCertificateTemplate is specific certificate template
+                  to use with the secondary CA pool
+                type: string
+              secondaryLocation:
+                description: SecondaryLocation is the Google Cloud Project Location
+                  for the secondary CA pool.
+                type: string
             type: object
           status:
             properties:

--- a/deploy/crds/cas-issuer.jetstack.io_googlecasissuers.yaml
+++ b/deploy/crds/cas-issuer.jetstack.io_googlecasissuers.yaml
@@ -98,24 +98,40 @@ spec:
               project:
                 description: Project is the Google Cloud Project ID
                 type: string
-              secondaryCaPoolId:
-                description: SecondaryCaPoolId is the id of a fallback CA pool to issue
-                  certificates from if the primary pool fails
-                type: string
-              secondaryCertificateAuthorityId:
+              fallbacks:
                 description: |-
-                  SecondaryCertificateAuthorityId is specific certificate authority from the fallback CA pool to
-                  use to sign. Omit in order to load balance across all CAs
-                  in the pool
-                type: string
-              secondaryCertificateTemplate:
-                description: SecondaryCertificateTemplate is specific certificate template
-                  to use with the secondary CA pool
-                type: string
-              secondaryLocation:
-                description: SecondaryLocation is the Google Cloud Project Location
-                  for the secondary CA pool.
-                type: string
+                  Fallbacks is an ordered list of fallback CA pools. If the primary pool fails,
+                  the controller tries each fallback in order until one succeeds.
+                items:
+                  description: FallbackCAPool defines a fallback CA pool configuration
+                    for failover.
+                  properties:
+                    caPoolId:
+                      description: CaPoolId is the CA pool ID for the fallback pool.
+                      type: string
+                    certificateAuthorityId:
+                      description: |-
+                        CertificateAuthorityId is a specific certificate authority within the fallback pool.
+                        Omit to load balance across all CAs in the pool.
+                      type: string
+                    certificateTemplate:
+                      description: CertificateTemplate is the certificate template
+                        to use with this fallback pool. Omit to not specify a template
+                      type: string
+                    location:
+                      description: Location is the Google Cloud location of the fallback
+                        pool.
+                      type: string
+                    project:
+                      description: Project is the Google Cloud Project ID for this
+                        fallback pool.
+                      type: string
+                  required:
+                  - project
+                  - caPoolId
+                  - location
+                  type: object
+                type: array
             type: object
           status:
             properties:

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -61,5 +61,6 @@ test-e2e: test-e2e-deps | kind-cluster $(NEEDS_GINKGO)
 		-- \
 		--kubeconfig $(CURDIR)/$(kind_kubeconfig) \
 		--project jetstack-cas --location europe-west1 --capoolid issuer-e2e \
-		$(if $(SECONDARY_CA_POOL_ID),--secondary-capoolid $(SECONDARY_CA_POOL_ID)) \
-		$(if $(SECONDARY_LOCATION),--secondary-location $(SECONDARY_LOCATION))
+		$(if $(FALLBACK_PROJECT),--fallback-project $(FALLBACK_PROJECT)) \
+		$(if $(FALLBACK_CA_POOL_ID),--fallback-capoolid $(FALLBACK_CA_POOL_ID)) \
+		$(if $(FALLBACK_LOCATION),--fallback-location $(FALLBACK_LOCATION))

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -60,4 +60,6 @@ test-e2e: test-e2e-deps | kind-cluster $(NEEDS_GINKGO)
 		./test/e2e/ \
 		-- \
 		--kubeconfig $(CURDIR)/$(kind_kubeconfig) \
-		--project jetstack-cas --location europe-west1 --capoolid issuer-e2e
+		--project jetstack-cas --location europe-west1 --capoolid issuer-e2e \
+		$(if $(SECONDARY_CA_POOL_ID),--secondary-capoolid $(SECONDARY_CA_POOL_ID)) \
+		$(if $(SECONDARY_LOCATION),--secondary-location $(SECONDARY_LOCATION))

--- a/pkg/controllers/signer.go
+++ b/pkg/controllers/signer.go
@@ -177,51 +177,55 @@ func (o *GoogleCAS) Sign(ctx context.Context, cr signer.CertificateRequestObject
 }
 
 // createCertificateWithFallback attempts to create a certificate using the primary CA pool.
-// If the primary attempt fails and a secondary CA pool is configured, it retries using the
-// fallback pool. Returns the certificate response, the parent string of the pool that
+// If the primary attempt fails and fallback CA pools are configured, it retries each
+// fallback in order. Returns the certificate response, the parent string of the pool that
 // successfully signed (for use in subsequent FetchCaCerts calls), and any error.
 func createCertificateWithFallback(
 	ctx context.Context,
 	casClient *privateca.CertificateAuthorityClient,
 	req *casapi.CreateCertificateRequest,
-	primaryParent string,
+	parent string,
 	issuerSpec *issuersv1beta1.GoogleCASIssuerSpec,
 ) (*casapi.Certificate, string, error) {
+
 	resp, err := casClient.CreateCertificate(ctx, req)
 	if err == nil {
-		return resp, primaryParent, nil
+		return resp, parent, nil
 	}
 
-	ctrl.LoggerFrom(ctx).Error(err, "casClient.CreateCertificate failed on primary CA pool")
-
-	// Fail fast if fallback is not configured
-	if !hasFallbackConfig(issuerSpec) {
-		return nil, "", fmt.Errorf("casClient.CreateCertificate failed (no fallback configured): %w", err)
+	// Fail fast if no fallbacks are configured
+	if len(issuerSpec.Fallbacks) == 0 {
+		return nil, "", fmt.Errorf("casClient.CreateCertificate failed (no fallbacks configured): %w", err)
 	}
 
-	secondaryParent, buildErr := buildSecondaryParentString(issuerSpec)
-	if buildErr != nil {
-		return nil, "", fmt.Errorf("failed to build fallback parent string: %v (primary error: %w)", buildErr, err)
+	// Try each fallback in order
+	var allErrs []error
+	allErrs = append(allErrs, fmt.Errorf("casClient.CreateCertificate failed on Primary CA pool %s: %w", parent, err))
+
+	for i, fb := range issuerSpec.Fallbacks {
+		fbParent, fbBuildErr := buildFallbackParentString(fb)
+		if fbBuildErr != nil {
+			allErrs = append(allErrs, fmt.Errorf("fallback[%d] build parent error: %w", i, fbBuildErr))
+			continue
+		}
+
+		req.CertificateId = fmt.Sprintf("cert-manager-%d", rand.Int())
+		req.Parent = fbParent
+		req.Certificate.CertificateTemplate = fb.CertificateTemplate
+		req.IssuingCertificateAuthorityId = fb.CertificateAuthorityId
+		req.RequestId = uuid.New().String()
+
+		resp, fbCertErr := casClient.CreateCertificate(ctx, req)
+		if fbCertErr != nil {
+			allErrs = append(allErrs, fmt.Errorf("fallback[%d] (%s) failed: %w", i, fbParent, fbCertErr))
+			continue
+		}
+
+		return resp, fbParent, nil
 	}
 
-	req.Parent = secondaryParent
-	req.Certificate.CertificateTemplate = issuerSpec.SecondaryCertificateTemplate
-	req.IssuingCertificateAuthorityId = issuerSpec.SecondaryCertificateAuthorityId
-
-	resp, fallbackErr := casClient.CreateCertificate(ctx, req)
-	if fallbackErr != nil {
-		return nil, "", fmt.Errorf("casClient.CreateCertificate failed on fallback CA pool: %w (primary error: %v)", fallbackErr, err)
-	}
-
-	ctrl.LoggerFrom(ctx).Info("Successfully signed certificate using fallback CA pool")
-	return resp, secondaryParent, nil
+	return nil, "", fmt.Errorf("casClient.CreateCertificate failed on Primary and all Fallback CA pools: %w", errors.Join(allErrs...))
 }
-
-// hasFallbackConfig returns true if all required secondary CA pool fields are set.
-func hasFallbackConfig(spec *issuersv1beta1.GoogleCASIssuerSpec) bool {
-	return spec.SecondaryCaPoolId != "" && spec.SecondaryLocation != "" && spec.SecondaryCertificateTemplate != ""
-}
-
 
 func buildParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, error) {
 	if issuerSpec.Project == "" {
@@ -239,22 +243,20 @@ func buildParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, 
 	return parent, nil
 }
 
-func buildSecondaryParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, error) {
-	if issuerSpec.Project == "" {
-		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Project")}
+func buildFallbackParentString(fb issuersv1beta1.FallbackCAPool) (string, error) {
+	if fb.Project == "" {
+		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Project in fallback")}
 	}
-	
-	if issuerSpec.SecondaryLocation == "" {
-		return "", signer.PermanentError{Err: fmt.Errorf("must specify a SecondaryLocation")}
+	if fb.Location == "" {
+		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Location in fallback")}
 	}
-
-	if issuerSpec.SecondaryCaPoolId == "" {
-		return "", signer.PermanentError{Err: fmt.Errorf("must specify a SecondaryCaPoolId")}
+	if fb.CaPoolId == "" {
+		return "", signer.PermanentError{Err: fmt.Errorf("must specify a CaPoolId in fallback")}
 	}
 
-	parent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", issuerSpec.Project, issuerSpec.SecondaryLocation, issuerSpec.SecondaryCaPoolId)
+	fbParent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", fb.Project, fb.Location, fb.CaPoolId)
 
-	return parent, nil
+	return fbParent, nil
 }
 
 func (c *GoogleCAS) createCasClient(ctx context.Context, resourceNamespace string, issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (*privateca.CertificateAuthorityClient, string, error) {

--- a/pkg/controllers/signer.go
+++ b/pkg/controllers/signer.go
@@ -141,9 +141,9 @@ func (o *GoogleCAS) Sign(ctx context.Context, cr signer.CertificateRequestObject
 		IssuingCertificateAuthorityId: issuerSpec.CertificateAuthorityId,
 	}
 
-	createCertResp, err := casClient.CreateCertificate(ctx, createCertificateRequest)
+	createCertResp, parent, err := createCertificateWithFallback(ctx, casClient, createCertificateRequest, parent, issuerSpec)
 	if err != nil {
-		return signer.PEMBundle{}, fmt.Errorf("casClient.CreateCertificate failed: %w", err)
+		return signer.PEMBundle{}, err
 	}
 
 	chainPEM, caPem, err := extractCertAndCA(createCertResp)
@@ -176,6 +176,53 @@ func (o *GoogleCAS) Sign(ctx context.Context, cr signer.CertificateRequestObject
 	}, err
 }
 
+// createCertificateWithFallback attempts to create a certificate using the primary CA pool.
+// If the primary attempt fails and a secondary CA pool is configured, it retries using the
+// fallback pool. Returns the certificate response, the parent string of the pool that
+// successfully signed (for use in subsequent FetchCaCerts calls), and any error.
+func createCertificateWithFallback(
+	ctx context.Context,
+	casClient *privateca.CertificateAuthorityClient,
+	req *casapi.CreateCertificateRequest,
+	primaryParent string,
+	issuerSpec *issuersv1beta1.GoogleCASIssuerSpec,
+) (*casapi.Certificate, string, error) {
+	resp, err := casClient.CreateCertificate(ctx, req)
+	if err == nil {
+		return resp, primaryParent, nil
+	}
+
+	ctrl.LoggerFrom(ctx).Error(err, "casClient.CreateCertificate failed on primary CA pool")
+
+	// Fail fast if fallback is not configured
+	if !hasFallbackConfig(issuerSpec) {
+		return nil, "", fmt.Errorf("casClient.CreateCertificate failed (no fallback configured): %w", err)
+	}
+
+	secondaryParent, buildErr := buildSecondaryParentString(issuerSpec)
+	if buildErr != nil {
+		return nil, "", fmt.Errorf("failed to build fallback parent string: %v (primary error: %w)", buildErr, err)
+	}
+
+	req.Parent = secondaryParent
+	req.Certificate.CertificateTemplate = issuerSpec.SecondaryCertificateTemplate
+	req.IssuingCertificateAuthorityId = issuerSpec.SecondaryCertificateAuthorityId
+
+	resp, fallbackErr := casClient.CreateCertificate(ctx, req)
+	if fallbackErr != nil {
+		return nil, "", fmt.Errorf("casClient.CreateCertificate failed on fallback CA pool: %w (primary error: %v)", fallbackErr, err)
+	}
+
+	ctrl.LoggerFrom(ctx).Info("Successfully signed certificate using fallback CA pool")
+	return resp, secondaryParent, nil
+}
+
+// hasFallbackConfig returns true if all required secondary CA pool fields are set.
+func hasFallbackConfig(spec *issuersv1beta1.GoogleCASIssuerSpec) bool {
+	return spec.SecondaryCaPoolId != "" && spec.SecondaryLocation != "" && spec.SecondaryCertificateTemplate != ""
+}
+
+
 func buildParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, error) {
 	if issuerSpec.Project == "" {
 		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Project")}
@@ -188,6 +235,24 @@ func buildParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, 
 	}
 
 	parent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", issuerSpec.Project, issuerSpec.Location, issuerSpec.CaPoolId)
+
+	return parent, nil
+}
+
+func buildSecondaryParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, error) {
+	if issuerSpec.Project == "" {
+		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Project")}
+	}
+	
+	if issuerSpec.SecondaryLocation == "" {
+		return "", signer.PermanentError{Err: fmt.Errorf("must specify a SecondaryLocation")}
+	}
+
+	if issuerSpec.SecondaryCaPoolId == "" {
+		return "", signer.PermanentError{Err: fmt.Errorf("must specify a SecondaryCaPoolId")}
+	}
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", issuerSpec.Project, issuerSpec.SecondaryLocation, issuerSpec.SecondaryCaPoolId)
 
 	return parent, nil
 }

--- a/pkg/controllers/signer.go
+++ b/pkg/controllers/signer.go
@@ -192,6 +192,11 @@ func createCertificateWithFallback(
 	if err == nil {
 		return resp, parent, nil
 	}
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Primary CA pool signing failed; triggering failover to fallback pools",
+		"primaryPool", parent,
+		"error", err,
+	)
 
 	// Fail fast if no fallbacks are configured
 	if len(issuerSpec.Fallbacks) == 0 {
@@ -203,7 +208,7 @@ func createCertificateWithFallback(
 	allErrs = append(allErrs, fmt.Errorf("casClient.CreateCertificate failed on Primary CA pool %s: %w", parent, err))
 
 	for i, fb := range issuerSpec.Fallbacks {
-		fbParent, fbBuildErr := buildFallbackParentString(fb)
+		fbParent, fbBuildErr := buildParentString(fb)
 		if fbBuildErr != nil {
 			allErrs = append(allErrs, fmt.Errorf("fallback[%d] build parent error: %w", i, fbBuildErr))
 			continue
@@ -227,36 +232,20 @@ func createCertificateWithFallback(
 	return nil, "", fmt.Errorf("casClient.CreateCertificate failed on Primary and all Fallback CA pools: %w", errors.Join(allErrs...))
 }
 
-func buildParentString(issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (string, error) {
-	if issuerSpec.Project == "" {
+func buildParentString(ref issuersv1beta1.CAPoolReference) (string, error) {
+	if ref.GetProject() == "" {
 		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Project")}
 	}
-	if issuerSpec.Location == "" {
+	if ref.GetLocation() == "" {
 		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Location")}
 	}
-	if issuerSpec.CaPoolId == "" {
+	if ref.GetCaPoolId() == "" {
 		return "", signer.PermanentError{Err: fmt.Errorf("must specify a CaPoolId")}
 	}
 
-	parent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", issuerSpec.Project, issuerSpec.Location, issuerSpec.CaPoolId)
+	parent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", ref.GetProject(), ref.GetLocation(), ref.GetCaPoolId())
 
 	return parent, nil
-}
-
-func buildFallbackParentString(fb issuersv1beta1.FallbackCAPool) (string, error) {
-	if fb.Project == "" {
-		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Project in fallback")}
-	}
-	if fb.Location == "" {
-		return "", signer.PermanentError{Err: fmt.Errorf("must specify a Location in fallback")}
-	}
-	if fb.CaPoolId == "" {
-		return "", signer.PermanentError{Err: fmt.Errorf("must specify a CaPoolId in fallback")}
-	}
-
-	fbParent := fmt.Sprintf("projects/%s/locations/%s/caPools/%s", fb.Project, fb.Location, fb.CaPoolId)
-
-	return fbParent, nil
 }
 
 func (c *GoogleCAS) createCasClient(ctx context.Context, resourceNamespace string, issuerSpec *issuersv1beta1.GoogleCASIssuerSpec) (*privateca.CertificateAuthorityClient, string, error) {

--- a/pkg/controllers/signer_test.go
+++ b/pkg/controllers/signer_test.go
@@ -65,101 +65,117 @@ func TestBuildParentStringMissingPoolId(t *testing.T) {
 	}
 }
 
+func TestBuildFallbackParentString(t *testing.T) {
+	tests := []struct {
+		name        string
+		fb          v1beta1.FallbackCAPool
+		wantParent  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "all fields specified",
+			fb: v1beta1.FallbackCAPool{
+				Project:  "fallback-project",
+				Location: "us-west1",
+				CaPoolId: "fb-pool",
+			},
+			wantParent: "projects/fallback-project/locations/us-west1/caPools/fb-pool",
+		},
+		{
+			name: "missing project",
+			fb: v1beta1.FallbackCAPool{
+				Location: "us-west1",
+				CaPoolId: "fb-pool",
+			},
+			wantErr:     true,
+			errContains: "must specify a Project",
+		},
+		{
+			name: "missing location",
+			fb: v1beta1.FallbackCAPool{
+				Project:  "project",
+				CaPoolId: "pool",
+			},
+			wantErr:     true,
+			errContains: "must specify a Location",
+		},
+		{
+			name: "missing CaPoolId",
+			fb: v1beta1.FallbackCAPool{
+				Project:  "project",
+				Location: "location",
+			},
+			wantErr:     true,
+			errContains: "must specify a CaPoolId",
+		},
+	}
 
-func TestBuildSecondaryParentString(t *testing.T) {
-	spec := &v1beta1.GoogleCASIssuerSpec{
-		Project:           "test-project",
-		SecondaryLocation: "secondary-location",
-		SecondaryCaPoolId: "secondary-pool",
-	}
-	parent, err := buildSecondaryParentString(spec)
-	if err != nil {
-		t.Errorf("buildSecondaryParentString returned an error: %s", err.Error())
-	}
-	if got, want := parent, fmt.Sprintf("projects/%s/locations/%s/caPools/%s", spec.Project, spec.SecondaryLocation, spec.SecondaryCaPoolId); got != want {
-		t.Errorf("Wrong parent: %s != %s", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildFallbackParentString(tt.fb)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantParent, got)
+			}
+		})
 	}
 }
 
-func TestBuildSecondaryParentStringMissingLocation(t *testing.T) {
-	spec := &v1beta1.GoogleCASIssuerSpec{
-		Project:           "test-project",
-		SecondaryLocation: "",
-		SecondaryCaPoolId: "secondary-pool",
-	}
-	_, err := buildSecondaryParentString(spec)
-	if err == nil {
-		t.Error("buildSecondaryParentString didn't return an error")
-	}
-	if got, want := err.Error(), "must specify a SecondaryLocation"; got != want {
-		t.Errorf("Wrong error: %s != %s", got, want)
-	}
-}
-
-func TestBuildSecondaryParentStringMissingPoolId(t *testing.T) {
-	spec := &v1beta1.GoogleCASIssuerSpec{
-		Project:           "test-project",
-		SecondaryLocation: "secondary-location",
-		SecondaryCaPoolId: "",
-	}
-	_, err := buildSecondaryParentString(spec)
-	if err == nil {
-		t.Error("buildSecondaryParentString didn't return an error")
-	}
-	if got, want := err.Error(), "must specify a SecondaryCaPoolId"; got != want {
-		t.Errorf("Wrong error: %s != %s", got, want)
-	}
-}
-
-func TestHasFallbackConfig(t *testing.T) {
+func TestHasFallbacks(t *testing.T) {
 	tests := []struct {
 		name string
 		spec *v1beta1.GoogleCASIssuerSpec
 		want bool
 	}{
 		{
-			name: "all secondary fields set",
+			name: "no fallbacks configured",
+			spec: &v1beta1.GoogleCASIssuerSpec{},
+			want: false,
+		},
+		{
+			name: "one fallback configured",
 			spec: &v1beta1.GoogleCASIssuerSpec{
-				SecondaryCaPoolId:            "pool",
-				SecondaryLocation:            "location",
-				SecondaryCertificateTemplate: "template",
+				Fallbacks: []v1beta1.FallbackCAPool{
+					{
+						CaPoolId:            "pool",
+						Location:            "location",
+						CertificateTemplate: "template",
+					},
+				},
 			},
 			want: true,
 		},
 		{
-			name: "missing SecondaryCaPoolId",
+			name: "multiple fallbacks configured",
 			spec: &v1beta1.GoogleCASIssuerSpec{
-				SecondaryLocation:            "location",
-				SecondaryCertificateTemplate: "template",
+				Fallbacks: []v1beta1.FallbackCAPool{
+					{
+						CaPoolId:            "pool1",
+						Location:            "location1",
+						CertificateTemplate: "template1",
+					},
+					{
+						Project:                "other-project",
+						CaPoolId:               "pool2",
+						Location:               "location2",
+						CertificateTemplate:    "template2",
+						CertificateAuthorityId: "ca-id",
+					},
+				},
 			},
-			want: false,
-		},
-		{
-			name: "missing SecondaryLocation",
-			spec: &v1beta1.GoogleCASIssuerSpec{
-				SecondaryCaPoolId:            "pool",
-				SecondaryCertificateTemplate: "template",
-			},
-			want: false,
-		},
-		{
-			name: "missing SecondaryCertificateTemplate",
-			spec: &v1beta1.GoogleCASIssuerSpec{
-				SecondaryCaPoolId: "pool",
-				SecondaryLocation: "location",
-			},
-			want: false,
-		},
-		{
-			name: "all secondary fields empty",
-			spec: &v1beta1.GoogleCASIssuerSpec{},
-			want: false,
+			want: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := hasFallbackConfig(tt.spec)
+			got := len(tt.spec.Fallbacks) > 0
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/controllers/signer_test.go
+++ b/pkg/controllers/signer_test.go
@@ -65,6 +65,106 @@ func TestBuildParentStringMissingPoolId(t *testing.T) {
 	}
 }
 
+
+func TestBuildSecondaryParentString(t *testing.T) {
+	spec := &v1beta1.GoogleCASIssuerSpec{
+		Project:           "test-project",
+		SecondaryLocation: "secondary-location",
+		SecondaryCaPoolId: "secondary-pool",
+	}
+	parent, err := buildSecondaryParentString(spec)
+	if err != nil {
+		t.Errorf("buildSecondaryParentString returned an error: %s", err.Error())
+	}
+	if got, want := parent, fmt.Sprintf("projects/%s/locations/%s/caPools/%s", spec.Project, spec.SecondaryLocation, spec.SecondaryCaPoolId); got != want {
+		t.Errorf("Wrong parent: %s != %s", got, want)
+	}
+}
+
+func TestBuildSecondaryParentStringMissingLocation(t *testing.T) {
+	spec := &v1beta1.GoogleCASIssuerSpec{
+		Project:           "test-project",
+		SecondaryLocation: "",
+		SecondaryCaPoolId: "secondary-pool",
+	}
+	_, err := buildSecondaryParentString(spec)
+	if err == nil {
+		t.Error("buildSecondaryParentString didn't return an error")
+	}
+	if got, want := err.Error(), "must specify a SecondaryLocation"; got != want {
+		t.Errorf("Wrong error: %s != %s", got, want)
+	}
+}
+
+func TestBuildSecondaryParentStringMissingPoolId(t *testing.T) {
+	spec := &v1beta1.GoogleCASIssuerSpec{
+		Project:           "test-project",
+		SecondaryLocation: "secondary-location",
+		SecondaryCaPoolId: "",
+	}
+	_, err := buildSecondaryParentString(spec)
+	if err == nil {
+		t.Error("buildSecondaryParentString didn't return an error")
+	}
+	if got, want := err.Error(), "must specify a SecondaryCaPoolId"; got != want {
+		t.Errorf("Wrong error: %s != %s", got, want)
+	}
+}
+
+func TestHasFallbackConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *v1beta1.GoogleCASIssuerSpec
+		want bool
+	}{
+		{
+			name: "all secondary fields set",
+			spec: &v1beta1.GoogleCASIssuerSpec{
+				SecondaryCaPoolId:            "pool",
+				SecondaryLocation:            "location",
+				SecondaryCertificateTemplate: "template",
+			},
+			want: true,
+		},
+		{
+			name: "missing SecondaryCaPoolId",
+			spec: &v1beta1.GoogleCASIssuerSpec{
+				SecondaryLocation:            "location",
+				SecondaryCertificateTemplate: "template",
+			},
+			want: false,
+		},
+		{
+			name: "missing SecondaryLocation",
+			spec: &v1beta1.GoogleCASIssuerSpec{
+				SecondaryCaPoolId:            "pool",
+				SecondaryCertificateTemplate: "template",
+			},
+			want: false,
+		},
+		{
+			name: "missing SecondaryCertificateTemplate",
+			spec: &v1beta1.GoogleCASIssuerSpec{
+				SecondaryCaPoolId: "pool",
+				SecondaryLocation: "location",
+			},
+			want: false,
+		},
+		{
+			name: "all secondary fields empty",
+			spec: &v1beta1.GoogleCASIssuerSpec{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasFallbackConfig(tt.spec)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestExtractCertAndCA(t *testing.T) {
 	type expected struct {
 		cert []byte

--- a/pkg/controllers/signer_test.go
+++ b/pkg/controllers/signer_test.go
@@ -113,7 +113,7 @@ func TestBuildFallbackParentString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildFallbackParentString(tt.fb)
+			got, err := buildParentString(tt.fb)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {

--- a/test/e2e/framework/config/config.go
+++ b/test/e2e/framework/config/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	Project  string
 	Location string
 	CaPoolId string
+
+	// Secondary CA pool config for failover tests (optional)
+	SecondaryCaPoolId string
+	SecondaryLocation string
 }
 
 var (
@@ -51,6 +55,8 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Project, "project", "", "GCP project name")
 	fs.StringVar(&c.Location, "location", "", "GCP project location")
 	fs.StringVar(&c.CaPoolId, "capoolid", "", "CA pool ID")
+	fs.StringVar(&c.SecondaryCaPoolId, "secondary-capoolid", "", "Secondary CA pool ID for failover tests (optional)")
+	fs.StringVar(&c.SecondaryLocation, "secondary-location", "", "Secondary CA pool location for failover tests (optional)")
 }
 
 func (c *Config) Validate() error {

--- a/test/e2e/framework/config/config.go
+++ b/test/e2e/framework/config/config.go
@@ -33,9 +33,10 @@ type Config struct {
 	Location string
 	CaPoolId string
 
-	// Secondary CA pool config for failover tests (optional)
-	SecondaryCaPoolId string
-	SecondaryLocation string
+	// Fallback CA pool config for failover tests (optional)
+	FallbackProject  string
+	FallbackCaPoolId string
+	FallbackLocation string
 }
 
 var (
@@ -55,8 +56,9 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.Project, "project", "", "GCP project name")
 	fs.StringVar(&c.Location, "location", "", "GCP project location")
 	fs.StringVar(&c.CaPoolId, "capoolid", "", "CA pool ID")
-	fs.StringVar(&c.SecondaryCaPoolId, "secondary-capoolid", "", "Secondary CA pool ID for failover tests (optional)")
-	fs.StringVar(&c.SecondaryLocation, "secondary-location", "", "Secondary CA pool location for failover tests (optional)")
+	fs.StringVar(&c.FallbackProject, "fallback-project", "", "Fallback CA pool project for failover tests (optional)")
+	fs.StringVar(&c.FallbackCaPoolId, "fallback-capoolid", "", "Fallback CA pool ID for failover tests (optional)")
+	fs.StringVar(&c.FallbackLocation, "fallback-location", "", "Fallback CA pool location for failover tests (optional)")
 }
 
 func (c *Config) Validate() error {

--- a/test/e2e/suite/issuers/issuers.go
+++ b/test/e2e/suite/issuers/issuers.go
@@ -81,17 +81,34 @@ spec:
   credentials:
     name: {{ .SecretName }}
     key: "{{ .SecretKey }}"`
+
+	issuerWithFallbackYAML string = `apiVersion: cas-issuer.jetstack.io/v1beta1
+kind: GoogleCASIssuer
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  project: {{ .Project }}
+  location: {{ .Location }}
+  caPoolId: {{ .Pool }}
+  credentials:
+    name: {{ .SecretName }}
+    key: "{{ .SecretKey }}"
+  secondaryCaPoolId: {{ .SecondaryPool }}
+  secondaryLocation: {{ .SecondaryLocation }}
 )
 
 type templateConfig struct {
-	Name        string
-	Namespace   string
-	Project     string
-	Location    string
-	Pool        string
-	SecretName  string
-	SecretKey   string
-	CAFetchMode string
+	Name              string
+	Namespace         string
+	Project           string
+	Location          string
+	Pool              string
+	SecretName        string
+	SecretKey         string
+	CAFetchMode       string
+	SecondaryPool     string
+	SecondaryLocation string
 }
 
 var _ = framework.CasesDescribe("issuers", func() {
@@ -343,6 +360,184 @@ var _ = framework.CasesDescribe("issuers", func() {
 
 		By("Verifying ca.crt contains multiple CA certificates from pool")
 		err = f.Helper().VerifyMultiplePoolCAs(cfg.Namespace, certName)
+		Expect(err).NotTo(HaveOccurred())
+	})
+		
+	It("Tests Issuer failover to secondary CA pool", func() {
+		if cfg.SecondaryCaPoolId == "" || cfg.SecondaryLocation == "" {
+			Skip("--secondary-capoolid and --secondary-location are required, skipping failover test")
+		}
+
+		By("Creating Google Cloud Credentials Secret")
+		data, err := os.ReadFile(os.Getenv("TEST_GOOGLE_APPLICATION_CREDENTIALS"))
+		Expect(err).NotTo(HaveOccurred())
+		secret, err := f.KubeClientSet.CoreV1().Secrets(cfg.Namespace).Create(
+			context.TODO(),
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "google-credentials-",
+					Namespace:    cfg.Namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"google.json": data,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Constructing an issuer with invalid primary and valid secondary CA pool")
+		t := &templateConfig{
+			Name:              "issuer-failover-" + util.RandomString(5),
+			Namespace:         cfg.Namespace,
+			Project:           cfg.Project,
+			Location:          cfg.Location,
+			Pool:              "nonexistent-pool-" + util.RandomString(5),
+			SecretName:        secret.Name,
+			SecretKey:         "google.json",
+			SecondaryPool:     cfg.SecondaryCaPoolId,
+			SecondaryLocation: cfg.SecondaryLocation,
+		}
+		buf := &bytes.Buffer{}
+		err = template.Must(template.New("issuer-failover").Parse(issuerWithFallbackYAML)).Execute(buf, t)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating dynamic object")
+		dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+		apiObject := &unstructured.Unstructured{}
+		_, gvk, err := dec.Decode(buf.Bytes(), nil, apiObject)
+		Expect(err).NotTo(HaveOccurred())
+		mapping, err := f.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		Expect(err).NotTo(HaveOccurred())
+
+		dr := f.DynamicClientSet.Resource(mapping.Resource)
+
+		By("Creating issuer " + t.Namespace + "/" + t.Name)
+		_, err = dr.Namespace(t.Namespace).Create(context.TODO(), apiObject, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for issuer to become ready")
+		err = f.Helper().WaitForUnstructuredReady(dr, t.Name, t.Namespace, 30*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a certificate (should be issued via secondary CA pool)")
+		certName := "casissuer-failover-e2e-" + util.RandomString(5)
+		_, err = f.CMClientSet.CertmanagerV1().Certificates(cfg.Namespace).Create(context.TODO(), &certmanagerv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      certName,
+				Namespace: cfg.Namespace,
+			},
+			Spec: certmanagerv1.CertificateSpec{
+				SecretName:  certName,
+				CommonName:  certName,
+				DNSNames:    []string{certName, "e2etests.invalid"},
+				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 8 * time.Hour},
+				IssuerRef: cmmetav1.ObjectReference{
+					Name:  t.Name,
+					Kind:  gvk.Kind,
+					Group: gvk.Group,
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for certificate to become ready")
+		_, err = f.Helper().WaitForCertificateReady(cfg.Namespace, certName, 30*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying chain and CA")
+		err = f.Helper().VerifyCMCertificate(cfg.Namespace, certName)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Tests Issuer with secondary CA pool configured", func() {
+		if cfg.SecondaryCaPoolId == "" || cfg.SecondaryLocation == "" {
+			Skip("--secondary-capoolid and --secondary-location are required, skipping secondary pool test")
+		}
+
+		By("Creating Google Cloud Credentials Secret")
+		data, err := os.ReadFile(os.Getenv("TEST_GOOGLE_APPLICATION_CREDENTIALS"))
+		Expect(err).NotTo(HaveOccurred())
+		secret, err := f.KubeClientSet.CoreV1().Secrets(cfg.Namespace).Create(
+			context.TODO(),
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "google-credentials-",
+					Namespace:    cfg.Namespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"google.json": data,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Constructing an issuer with both primary and secondary CA pools")
+		t := &templateConfig{
+			Name:              "issuer-secondary-" + util.RandomString(5),
+			Namespace:         cfg.Namespace,
+			Project:           cfg.Project,
+			Location:          cfg.Location,
+			Pool:              cfg.CaPoolId,
+			SecretName:        secret.Name,
+			SecretKey:         "google.json",
+			SecondaryPool:     cfg.SecondaryCaPoolId,
+			SecondaryLocation: cfg.SecondaryLocation,
+		}
+		buf := &bytes.Buffer{}
+		err = template.Must(template.New("issuer-secondary").Parse(issuerWithFallbackYAML)).Execute(buf, t)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating dynamic object")
+		dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+		apiObject := &unstructured.Unstructured{}
+		_, gvk, err := dec.Decode(buf.Bytes(), nil, apiObject)
+		Expect(err).NotTo(HaveOccurred())
+		mapping, err := f.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		Expect(err).NotTo(HaveOccurred())
+
+		dr := f.DynamicClientSet.Resource(mapping.Resource)
+
+		By("Creating issuer " + t.Namespace + "/" + t.Name)
+		_, err = dr.Namespace(t.Namespace).Create(context.TODO(), apiObject, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for issuer to become ready")
+		err = f.Helper().WaitForUnstructuredReady(dr, t.Name, t.Namespace, 10*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a certificate (should be issued via primary CA pool)")
+		certName := "casissuer-secondary-e2e-" + util.RandomString(5)
+		_, err = f.CMClientSet.CertmanagerV1().Certificates(cfg.Namespace).Create(context.TODO(), &certmanagerv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      certName,
+				Namespace: cfg.Namespace,
+			},
+			Spec: certmanagerv1.CertificateSpec{
+				SecretName:  certName,
+				CommonName:  certName,
+				DNSNames:    []string{certName, "e2etests.invalid"},
+				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 8 * time.Hour},
+				IssuerRef: cmmetav1.ObjectReference{
+					Name:  t.Name,
+					Kind:  gvk.Kind,
+					Group: gvk.Group,
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for certificate to become ready")
+		_, err = f.Helper().WaitForCertificateReady(cfg.Namespace, certName, 10*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying chain and CA")
+		err = f.Helper().VerifyCMCertificate(cfg.Namespace, certName)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/suite/issuers/issuers.go
+++ b/test/e2e/suite/issuers/issuers.go
@@ -82,20 +82,24 @@ spec:
     name: {{ .SecretName }}
     key: "{{ .SecretKey }}"`
 
-	issuerWithFallbackYAML string = `apiVersion: cas-issuer.jetstack.io/v1beta1
-kind: GoogleCASIssuer
-metadata:
-  name: {{ .Name }}
-  namespace: {{ .Namespace }}
-spec:
-  project: {{ .Project }}
-  location: {{ .Location }}
-  caPoolId: {{ .Pool }}
-  credentials:
-    name: {{ .SecretName }}
-    key: "{{ .SecretKey }}"
-  secondaryCaPoolId: {{ .SecondaryPool }}
-  secondaryLocation: {{ .SecondaryLocation }}
+    issuerWithFallbackYAML string = `apiVersion: cas-issuer.jetstack.io/v1beta1
+    kind: GoogleCASIssuer
+    metadata:
+      name: {{ .Name }}
+      namespace: {{ .Namespace }}
+    spec:
+      project: {{ .Project }}
+      location: {{ .Location }}
+      caPoolId: {{ .Pool }}
+      credentials:
+        name: {{ .SecretName }}
+        key: "{{ .SecretKey }}"
+      fallbacks:
+        - project: {{ .FallbackProject }}
+          caPoolId: {{ .FallbackCAPoolId }}
+          location: {{ .FallbackLocation }}
+          certificateTemplate: ""
+`
 )
 
 type templateConfig struct {
@@ -107,8 +111,9 @@ type templateConfig struct {
 	SecretName        string
 	SecretKey         string
 	CAFetchMode       string
-	SecondaryPool     string
-	SecondaryLocation string
+	FallbackProject  string
+	FallbackCaPoolId string
+	FallbackLocation string
 }
 
 var _ = framework.CasesDescribe("issuers", func() {
@@ -363,181 +368,183 @@ var _ = framework.CasesDescribe("issuers", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 		
-	It("Tests Issuer failover to secondary CA pool", func() {
-		if cfg.SecondaryCaPoolId == "" || cfg.SecondaryLocation == "" {
-			Skip("--secondary-capoolid and --secondary-location are required, skipping failover test")
-		}
+	It("Tests Issuer failover to fallback CA pool", func() {
+			if cfg.FallbackProject == "" || cfg.FallbackCaPoolId == "" || cfg.FallbackLocation == "" {
+				Skip("--fallback-project, --fallback-capoolid and --fallback-location are required, skipping failover test")
+			}
 
-		By("Creating Google Cloud Credentials Secret")
-		data, err := os.ReadFile(os.Getenv("TEST_GOOGLE_APPLICATION_CREDENTIALS"))
-		Expect(err).NotTo(HaveOccurred())
-		secret, err := f.KubeClientSet.CoreV1().Secrets(cfg.Namespace).Create(
-			context.TODO(),
-			&corev1.Secret{
+			By("Creating Google Cloud Credentials Secret")
+			data, err := os.ReadFile(os.Getenv("TEST_GOOGLE_APPLICATION_CREDENTIALS"))
+			Expect(err).NotTo(HaveOccurred())
+			secret, err := f.KubeClientSet.CoreV1().Secrets(cfg.Namespace).Create(
+				context.TODO(),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "google-credentials-",
+						Namespace:    cfg.Namespace,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"google.json": data,
+					},
+				},
+				metav1.CreateOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Constructing an issuer with invalid primary and valid fallback CA pool")
+			t := &templateConfig{
+				Name:             "issuer-failover-" + util.RandomString(5),
+				Namespace:        cfg.Namespace,
+				Project:          cfg.Project,
+				Location:         cfg.Location,
+				Pool:             "nonexistent-pool-" + util.RandomString(5),
+				SecretName:       secret.Name,
+				SecretKey:        "google.json",
+				FallbackProject:  cfg.FallbackProject,
+				FallbackCaPoolId: cfg.FallbackCaPoolId,
+				FallbackLocation: cfg.FallbackLocation,
+			}
+			buf := &bytes.Buffer{}
+			err = template.Must(template.New("issuer-failover").Parse(issuerWithFallbackYAML)).Execute(buf, t)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating dynamic object")
+			dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+			apiObject := &unstructured.Unstructured{}
+			_, gvk, err := dec.Decode(buf.Bytes(), nil, apiObject)
+			Expect(err).NotTo(HaveOccurred())
+			mapping, err := f.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+			Expect(err).NotTo(HaveOccurred())
+
+			dr := f.DynamicClientSet.Resource(mapping.Resource)
+
+			By("Creating issuer " + t.Namespace + "/" + t.Name)
+			_, err = dr.Namespace(t.Namespace).Create(context.TODO(), apiObject, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for issuer to become ready")
+			err = f.Helper().WaitForUnstructuredReady(dr, t.Name, t.Namespace, 30*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a certificate (should be issued via fallback CA pool)")
+			certName := "casissuer-failover-e2e-" + util.RandomString(5)
+			_, err = f.CMClientSet.CertmanagerV1().Certificates(cfg.Namespace).Create(context.TODO(), &certmanagerv1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "google-credentials-",
-					Namespace:    cfg.Namespace,
+					Name:      certName,
+					Namespace: cfg.Namespace,
 				},
-				Type: corev1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					"google.json": data,
+				Spec: certmanagerv1.CertificateSpec{
+					SecretName:  certName,
+					CommonName:  certName,
+					DNSNames:    []string{certName, "e2etests.invalid"},
+					Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+					RenewBefore: &metav1.Duration{Duration: 8 * time.Hour},
+					IssuerRef: cmmetav1.ObjectReference{
+						Name:  t.Name,
+						Kind:  gvk.Kind,
+						Group: gvk.Group,
+					},
 				},
-			},
-			metav1.CreateOptions{},
-		)
-		Expect(err).NotTo(HaveOccurred())
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Constructing an issuer with invalid primary and valid secondary CA pool")
-		t := &templateConfig{
-			Name:              "issuer-failover-" + util.RandomString(5),
-			Namespace:         cfg.Namespace,
-			Project:           cfg.Project,
-			Location:          cfg.Location,
-			Pool:              "nonexistent-pool-" + util.RandomString(5),
-			SecretName:        secret.Name,
-			SecretKey:         "google.json",
-			SecondaryPool:     cfg.SecondaryCaPoolId,
-			SecondaryLocation: cfg.SecondaryLocation,
-		}
-		buf := &bytes.Buffer{}
-		err = template.Must(template.New("issuer-failover").Parse(issuerWithFallbackYAML)).Execute(buf, t)
-		Expect(err).NotTo(HaveOccurred())
+			By("Waiting for certificate to become ready")
+			_, err = f.Helper().WaitForCertificateReady(cfg.Namespace, certName, 30*time.Second)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Creating dynamic object")
-		dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-		apiObject := &unstructured.Unstructured{}
-		_, gvk, err := dec.Decode(buf.Bytes(), nil, apiObject)
-		Expect(err).NotTo(HaveOccurred())
-		mapping, err := f.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		Expect(err).NotTo(HaveOccurred())
+			By("Verifying chain and CA")
+			err = f.Helper().VerifyCMCertificate(cfg.Namespace, certName)
+			Expect(err).NotTo(HaveOccurred())
+		})
 
-		dr := f.DynamicClientSet.Resource(mapping.Resource)
+		It("Tests Issuer with fallback CA pool configured", func() {
+			if cfg.FallbackProject == "" || cfg.FallbackCaPoolId == "" || cfg.FallbackLocation == "" {
+				Skip("--fallback-project, --fallback-capoolid and --fallback-location are required, skipping fallback pool test")
+			}
 
-		By("Creating issuer " + t.Namespace + "/" + t.Name)
-		_, err = dr.Namespace(t.Namespace).Create(context.TODO(), apiObject, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for issuer to become ready")
-		err = f.Helper().WaitForUnstructuredReady(dr, t.Name, t.Namespace, 30*time.Second)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Creating a certificate (should be issued via secondary CA pool)")
-		certName := "casissuer-failover-e2e-" + util.RandomString(5)
-		_, err = f.CMClientSet.CertmanagerV1().Certificates(cfg.Namespace).Create(context.TODO(), &certmanagerv1.Certificate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      certName,
-				Namespace: cfg.Namespace,
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				SecretName:  certName,
-				CommonName:  certName,
-				DNSNames:    []string{certName, "e2etests.invalid"},
-				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
-				RenewBefore: &metav1.Duration{Duration: 8 * time.Hour},
-				IssuerRef: cmmetav1.ObjectReference{
-					Name:  t.Name,
-					Kind:  gvk.Kind,
-					Group: gvk.Group,
+			By("Creating Google Cloud Credentials Secret")
+			data, err := os.ReadFile(os.Getenv("TEST_GOOGLE_APPLICATION_CREDENTIALS"))
+			Expect(err).NotTo(HaveOccurred())
+			secret, err := f.KubeClientSet.CoreV1().Secrets(cfg.Namespace).Create(
+				context.TODO(),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "google-credentials-",
+						Namespace:    cfg.Namespace,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"google.json": data,
+					},
 				},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+				metav1.CreateOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for certificate to become ready")
-		_, err = f.Helper().WaitForCertificateReady(cfg.Namespace, certName, 30*time.Second)
-		Expect(err).NotTo(HaveOccurred())
+			By("Constructing an issuer with both primary and fallback CA pools")
+			t := &templateConfig{
+				Name:             "issuer-fallback-" + util.RandomString(5),
+				Namespace:        cfg.Namespace,
+				Project:          cfg.Project,
+				Location:         cfg.Location,
+				Pool:             cfg.CaPoolId,
+				SecretName:       secret.Name,
+				SecretKey:        "google.json",
+				FallbackProject:  cfg.FallbackProject,
+				FallbackCaPoolId: cfg.FallbackCaPoolId,
+				FallbackLocation: cfg.FallbackLocation,
+			}
+			buf := &bytes.Buffer{}
+			err = template.Must(template.New("issuer-fallback").Parse(issuerWithFallbackYAML)).Execute(buf, t)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Verifying chain and CA")
-		err = f.Helper().VerifyCMCertificate(cfg.Namespace, certName)
-		Expect(err).NotTo(HaveOccurred())
-	})
+			By("Creating dynamic object")
+			dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+			apiObject := &unstructured.Unstructured{}
+			_, gvk, err := dec.Decode(buf.Bytes(), nil, apiObject)
+			Expect(err).NotTo(HaveOccurred())
+			mapping, err := f.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+			Expect(err).NotTo(HaveOccurred())
 
-	It("Tests Issuer with secondary CA pool configured", func() {
-		if cfg.SecondaryCaPoolId == "" || cfg.SecondaryLocation == "" {
-			Skip("--secondary-capoolid and --secondary-location are required, skipping secondary pool test")
-		}
+			dr := f.DynamicClientSet.Resource(mapping.Resource)
 
-		By("Creating Google Cloud Credentials Secret")
-		data, err := os.ReadFile(os.Getenv("TEST_GOOGLE_APPLICATION_CREDENTIALS"))
-		Expect(err).NotTo(HaveOccurred())
-		secret, err := f.KubeClientSet.CoreV1().Secrets(cfg.Namespace).Create(
-			context.TODO(),
-			&corev1.Secret{
+			By("Creating issuer " + t.Namespace + "/" + t.Name)
+			_, err = dr.Namespace(t.Namespace).Create(context.TODO(), apiObject, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for issuer to become ready")
+			err = f.Helper().WaitForUnstructuredReady(dr, t.Name, t.Namespace, 10*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a certificate (should be issued via primary CA pool)")
+			certName := "casissuer-secondary-e2e-" + util.RandomString(5)
+			_, err = f.CMClientSet.CertmanagerV1().Certificates(cfg.Namespace).Create(context.TODO(), &certmanagerv1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "google-credentials-",
-					Namespace:    cfg.Namespace,
+					Name:      certName,
+					Namespace: cfg.Namespace,
 				},
-				Type: corev1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					"google.json": data,
+				Spec: certmanagerv1.CertificateSpec{
+					SecretName:  certName,
+					CommonName:  certName,
+					DNSNames:    []string{certName, "e2etests.invalid"},
+					Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+					RenewBefore: &metav1.Duration{Duration: 8 * time.Hour},
+					IssuerRef: cmmetav1.ObjectReference{
+						Name:  t.Name,
+						Kind:  gvk.Kind,
+						Group: gvk.Group,
+					},
 				},
-			},
-			metav1.CreateOptions{},
-		)
-		Expect(err).NotTo(HaveOccurred())
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Constructing an issuer with both primary and secondary CA pools")
-		t := &templateConfig{
-			Name:              "issuer-secondary-" + util.RandomString(5),
-			Namespace:         cfg.Namespace,
-			Project:           cfg.Project,
-			Location:          cfg.Location,
-			Pool:              cfg.CaPoolId,
-			SecretName:        secret.Name,
-			SecretKey:         "google.json",
-			SecondaryPool:     cfg.SecondaryCaPoolId,
-			SecondaryLocation: cfg.SecondaryLocation,
-		}
-		buf := &bytes.Buffer{}
-		err = template.Must(template.New("issuer-secondary").Parse(issuerWithFallbackYAML)).Execute(buf, t)
-		Expect(err).NotTo(HaveOccurred())
+			By("Waiting for certificate to become ready")
+			_, err = f.Helper().WaitForCertificateReady(cfg.Namespace, certName, 10*time.Second)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Creating dynamic object")
-		dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-		apiObject := &unstructured.Unstructured{}
-		_, gvk, err := dec.Decode(buf.Bytes(), nil, apiObject)
-		Expect(err).NotTo(HaveOccurred())
-		mapping, err := f.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		Expect(err).NotTo(HaveOccurred())
-
-		dr := f.DynamicClientSet.Resource(mapping.Resource)
-
-		By("Creating issuer " + t.Namespace + "/" + t.Name)
-		_, err = dr.Namespace(t.Namespace).Create(context.TODO(), apiObject, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for issuer to become ready")
-		err = f.Helper().WaitForUnstructuredReady(dr, t.Name, t.Namespace, 10*time.Second)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Creating a certificate (should be issued via primary CA pool)")
-		certName := "casissuer-secondary-e2e-" + util.RandomString(5)
-		_, err = f.CMClientSet.CertmanagerV1().Certificates(cfg.Namespace).Create(context.TODO(), &certmanagerv1.Certificate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      certName,
-				Namespace: cfg.Namespace,
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				SecretName:  certName,
-				CommonName:  certName,
-				DNSNames:    []string{certName, "e2etests.invalid"},
-				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
-				RenewBefore: &metav1.Duration{Duration: 8 * time.Hour},
-				IssuerRef: cmmetav1.ObjectReference{
-					Name:  t.Name,
-					Kind:  gvk.Kind,
-					Group: gvk.Group,
-				},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Waiting for certificate to become ready")
-		_, err = f.Helper().WaitForCertificateReady(cfg.Namespace, certName, 10*time.Second)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Verifying chain and CA")
-		err = f.Helper().VerifyCMCertificate(cfg.Namespace, certName)
-		Expect(err).NotTo(HaveOccurred())
-	})
+			By("Verifying chain and CA")
+			err = f.Helper().VerifyCMCertificate(cfg.Namespace, certName)
+			Expect(err).NotTo(HaveOccurred())
+		})
 })


### PR DESCRIPTION
## What this PR does

Adds support for configuring a **secondary (fallback) CA pool** in `GoogleCASIssuer` and `GoogleCASClusterIssuer` resources. When the primary CA pool fails to issue a certificate, the controller automatically retries using the configured secondary pool — enabling high availability for certificate issuance across GCP regions.

Closes <https://github.com/cert-manager/google-cas-issuer/issues/500>

## Why

In production environments, certificate issuance is a critical path. If the primary Google Cloud CAS CA pool becomes unavailable (regional outage, quota exhaustion, maintenance), all certificate issuance halts. This feature enables operators to configure a standby CA pool for automatic failover without manual intervention.

## How it works

1. The controller first attempts to issue the certificate using the **primary** CA pool.
2. If the primary attempt fails and all required secondary fields are configured (`secondaryCaPoolId`, `secondaryLocation`, `secondaryCertificateTemplate`), the controller retries using the **secondary** CA pool.
3. If the secondary attempt also fails, the error includes context from both failures.
4. If no secondary pool is configured, behavior is **unchanged** (fully backward compatible).

## Changes

### API / CRD
- **`api/v1beta1/googlecasissuer_types.go`** — Added 4 new optional fields to `GoogleCASIssuerSpec`:
  - `secondaryCaPoolId` — Fallback CA pool ID
  - `secondaryLocation` — GCP location of the fallback pool
  - `secondaryCertificateTemplate` — Certificate template for the fallback pool
  - `secondaryCertificateAuthorityId` — Specific CA within the fallback pool (optional)
- **`deploy/crds/`** — Updated both standalone CRD YAMLs with new fields
- **`deploy/charts/google-cas-issuer/templates/crd-*.yaml`** — Updated both Helm chart CRD templates with new fields

### Controller Logic
- **`pkg/controllers/signer.go`** — Added:
  - `createCertificateWithFallback()` — orchestrates primary → fallback signing
  - `hasFallbackConfig()` — checks if all required secondary fields are set
  - `buildSecondaryParentString()` — constructs the GCP resource path for the secondary pool

### Tests
- **`pkg/controllers/signer_test.go`** — Unit tests for:
  - `TestBuildSecondaryParentString` — validates secondary parent string construction
  - `TestBuildSecondaryParentStringMissingLocation` — error on missing location
  - `TestBuildSecondaryParentStringMissingPoolId` — error on missing pool ID
  - `TestHasFallbackConfig` — table-driven tests for all field combinations
- **`test/e2e/suite/issuers/issuers.go`** — Two new e2e test cases:
  - `Tests Issuer failover to secondary CA pool` — invalid primary + valid secondary
  - `Tests Issuer with secondary CA pool configured` — both valid, verifies primary is used
- **`test/e2e/framework/config/config.go`** — Added `--secondary-capoolid` and `--secondary-location` CLI flags
- **`make/test-e2e.mk`** — Added optional `SECONDARY_CA_POOL_ID` and `SECONDARY_LOCATION` env vars

### Documentation
- **`README.md`** — Added "Failover / Secondary CA Pool" section with configuration example and IAM requirements

## Example Configuration

```yaml
apiVersion: cas-issuer.jetstack.io/v1beta1
kind: GoogleCASIssuer
metadata:
  name: ha-issuer
spec:
  project: my-gcp-project
  location: us-east1
  caPoolId: primary-pool
  certificateTemplate: projects/my-gcp-project/locations/us-east1/certificateTemplates/my-template
  credentials:
    name: "gcp-sa-secret"
    key: "credentials.json"
  # Failover configuration
  secondaryCaPoolId: dr-pool
  secondaryLocation: us-west1
  secondaryCertificateTemplate: projects/my-gcp-project/locations/us-west1/certificateTemplates/dr-template
```

## IAM Requirements

The GCP service account must have `roles/privateca.certificateRequester` on **both** the primary and secondary CA pools:

```shell
# Primary pool
gcloud privateca pools add-iam-policy-binding primary-pool \
  --role=roles/privateca.certificateRequester \
  --member="serviceAccount:SA_NAME@PROJECT.iam.gserviceaccount.com" \
  --location=us-east1

# Secondary pool
gcloud privateca pools add-iam-policy-binding dr-pool \
  --role=roles/privateca.certificateRequester \
  --member="serviceAccount:SA_NAME@PROJECT.iam.gserviceaccount.com" \
  --location=us-west1
```

## Testing

### Unit tests
```shell
go test ./pkg/controllers/... -run "TestBuildSecondaryParentString|TestHasFallbackConfig" -v
```

### E2E tests (requires GCP infrastructure)
```shell
SECONDARY_CA_POOL_ID=dr-pool SECONDARY_LOCATION=us-west1 make test-e2e
```

E2E failover tests are **automatically skipped** if secondary pool flags are not provided — existing CI is unaffected.

## Backward Compatibility

- No breaking changes — all new fields are optional
- Existing `GoogleCASIssuer` / `GoogleCASClusterIssuer` resources work without modification
- CRD update is additive — new fields are added, no existing fields modified
- Controller behavior unchanged when secondary fields are not configured
