### PR TITLE
feat(chart): expose automountServiceAccountToken in the google-cas-issuer chart

### DIFF
--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -182,6 +182,14 @@ Optional additional annotations to add to the google-cas-issuer Pods
 > ```
 
 Optional additional labels to add to the google-cas-issuer Pods
+#### **automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automounting API credentials for the google-cas-issuer pod.
+
 #### **resources** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "cert-manager-google-cas-issuer.name" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/deploy/charts/google-cas-issuer/values.schema.json
+++ b/deploy/charts/google-cas-issuer/values.schema.json
@@ -9,6 +9,9 @@
         "app": {
           "$ref": "#/$defs/helm-values.app"
         },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.automountServiceAccountToken"
+        },
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
@@ -165,6 +168,11 @@
       "default": 9402,
       "description": "Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.",
       "type": "number"
+    },
+    "helm-values.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automounting API credentials for the google-cas-issuer pod.",
+      "type": "boolean"
     },
     "helm-values.commonLabels": {
       "default": {},

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -117,6 +117,10 @@ podAnnotations: {}
 # Optional additional labels to add to the google-cas-issuer Pods
 podLabels: {}
 
+# Automounting API credentials for the google-cas-issuer pod.
+# +docs:property
+automountServiceAccountToken: true
+
 # Kubernetes pod resource requests/limits for google-cas-issuer.
 # For example:
 #  limits:


### PR DESCRIPTION
## What
Adds an `automountServiceAccountToken` value to the google-cas-issuer chart so operators can disable automatic mounting of the ServiceAccount token on the pod — a common security-hardening request, matching the option already in the trust-manager chart.

## Details
- New `automountServiceAccountToken` value (defaults to `true`, preserving current behaviour).
- Rendered on the pod spec via `{{- if hasKey .Values "automountServiceAccountToken" }}`.
- Regenerated `values.schema.json` and `README.md` with `helm-tool`.

`helm lint` passes; `helm template --set automountServiceAccountToken=false` renders the field correctly.